### PR TITLE
Add iced-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "iced-coffee-script": "",
     "iced-utils" : ">=0.1.1",
+    "iced-runtime" : "*",
     "keybase-bitcoin": ">=0.0.0",
     "triplesec" : "keybase/triplesec#header_v3",
     "browserify" : "*",


### PR DESCRIPTION
While following the readme I received the following error:

``` bash
$ icake build

/Users/jareddeckard/Github/warpwallet/Cakefile:661
          throw err;
                ^
Error: module "iced-runtime" not found from "/Users/jareddeckard/Github/warpwallet/src/iced/top.iced"
```

It seems that I just needed to install `iced-runtime`.
