### PR TITLE
Fix a broken link in release.txt

### DIFF
--- a/release.txt.in
+++ b/release.txt.in
@@ -1,5 +1,5 @@
 
-WarpWallet --- https://keybase.io/warpwallet
+WarpWallet --- https://keybase.io/warp/
 ==========
 
 A brainwallet for Bitcoins, served as a self-contained HTML page with


### PR DESCRIPTION
https://keybase.io/warpwallet (404) => https://keybase.io/warp/ (working)